### PR TITLE
Update styling for Studio preview message

### DIFF
--- a/edx_reverification_block/xblock/static/html/studio_preview.html
+++ b/edx_reverification_block/xblock/static/html/studio_preview.html
@@ -11,14 +11,4 @@
 </div>
 {% endif %}
 
-<div class="xblock-header-secondary">
-    <div class="meta-info">{% trans "To preview the checkpoint block, click Preview or View Live in Unit Settings." %}</div>
-    <ul class="actions-list">
-        <li class="action-item action-view">
-            <a class="action-button" href="{{ view_container_link }}">
-                <span class="action-button-text">{% trans "View" %}</span>
-                <i class="icon fa fa-arrow-right"></i>
-            </a>
-        </li>
-    </ul>
-</div>
+<div class="reverify-preview-msg">{% trans "To preview the checkpoint block, click Preview or View Live in Unit Settings." %}</div>


### PR DESCRIPTION
* Remove styling to avoid negative margin issue.
* Remove "View" button.

This is what it looks like now:
![image](https://cloud.githubusercontent.com/assets/2948394/7350341/c31006a4-eccc-11e4-8b4d-31601293bea5.png)

@frrrances does this seem reasonable?