### PR TITLE
fix brokent ICRV 'skip_verification'

### DIFF
--- a/edx_reverification_block/xblock/reverification_block.py
+++ b/edx_reverification_block/xblock/reverification_block.py
@@ -265,7 +265,8 @@ class ReverificationBlock(XBlock):
         """
         self.runtime.service(self, "reverification").skip_verification(
             self.scope_ids.user_id,
-            self.course_id
+            self.course_id,
+            unicode(self.scope_ids.usage_id)
         )
         return {'success': True}
 

--- a/edx_reverification_block/xblock/tests/test_reverification_block.py
+++ b/edx_reverification_block/xblock/tests/test_reverification_block.py
@@ -174,7 +174,12 @@ class TestStudentView(XBlockHandlerTestCaseMixin, TestCase):
     @scenario(TESTS_BASE_DIR + '/data/basic_scenario.xml', user_id='bob')
     def test_skip_reverification(self, xblock):
         # Skip verification
-        response = self.request(xblock, "skip_verification", json.dumps(""), response_format="json")
+        payload = {
+            'user_id': xblock.scope_ids.user_id,
+            'course_id': xblock.course_id,
+            'checkpoint_location': unicode(xblock.scope_ids.usage_id)
+        }
+        response = self.request(xblock, "skip_verification", json.dumps(payload), response_format="json")
         self.assertTrue(response['success'])
 
         # Reloading the student view, we should see that we've skipped

--- a/stub_verification/models.py
+++ b/stub_verification/models.py
@@ -35,3 +35,4 @@ class SkipVerification(models.Model):
     """Track whether the user skipped verification for a course. """
     course_id = models.CharField(max_length=255, db_index=True)
     user_id = models.CharField(max_length=255)
+    checkpoint_location = models.CharField(max_length=255)

--- a/stub_verification/service.py
+++ b/stub_verification/service.py
@@ -40,11 +40,12 @@ class StubVerificationService(object):
             unicode(self.runtime.user_id)
         ))
 
-    def skip_verification(self, user_id, course_id):
+    def skip_verification(self, user_id, course_id, related_assessment_location):
         """Mark that the user has skipped verification for the course. """
         SkipVerification.objects.get_or_create(
-            course_id=course_id,
             user_id=user_id,
+            course_id=course_id,
+            checkpoint_location=related_assessment_location
         )
 
     def get_attempts(self, user_id, course_id, related_assessment_location):

--- a/stub_verification/tests/test_service.py
+++ b/stub_verification/tests/test_service.py
@@ -44,7 +44,7 @@ class StubVerificationServiceTest(TestCase):
 
     def test_skip_verification(self):
         # Skip verification
-        self.service.skip_verification(self.USER_ID, self.COURSE_ID)
+        self.service.skip_verification(self.USER_ID, self.COURSE_ID, self.ITEM_ID)
 
         # Check that the status is "skipped"
         self.assertEqual(self._get_status(), "skipped")


### PR DESCRIPTION
ECOM-1738
@awais786 @aamir-khan @ahsan-ul-haq @wedaly 
`skip_verification` method of LMS service `ReverificationService` needs `location` of `reverification` block.