### PR TITLE
ICRV: UI text changes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Aamir Khan <muhammad.aamir@abrisoft.com>
 Awais Qureshi <awais.qureshi@arbisoft.com>
 Will Daly <will@edx.org>
 Zubair Afzal <zubair.afzal@arbisoft.com>
+Ahsan Ulhaq <ahsan.ulhaq84@gmail.com>

--- a/edx_reverification_block/xblock/reverification_block.py
+++ b/edx_reverification_block/xblock/reverification_block.py
@@ -29,7 +29,7 @@ class ReverificationBlock(XBlock):
     # Fields
     display_name = String(
         scope=Scope.settings,
-        default='Re-Verification Checkpoint',
+        default='Reverification Checkpoint',
         help="This name appears in the horizontal navigation at the top of "
              "the page."
     )
@@ -38,16 +38,15 @@ class ReverificationBlock(XBlock):
         display_name="Verification Attempts",
         default=0,
         scope=Scope.settings,
-        help="This is the number of attempts that students are permitted to "
-             "get a valid re-verification."
+        help="The number of times learners can attempt to verify their identity."
     )
 
     related_assessment = String(
-        display_name="Related Assessment",
+        display_name="Associated Assessment",
         scope=Scope.content,
         default=CHECKPOINT_NAME,
-        help="This name will allow you to distinguish distinct checkpoints "
-             "that show up in the reporting about student verification status."
+        help="The display name of the associated assessment. "
+             "You can create the assessment either before or after you create the associated checkpoint."
     )
 
     is_configured = Boolean(
@@ -321,8 +320,8 @@ class ReverificationBlock(XBlock):
                 ValidationMessage(
                     ValidationMessage.WARNING,
                     self._(
-                        u"This checkpoint is not associated with an assessment yet. "
-                        u"Please select an Assessment."
+                        u"This checkpoint is not associated with an assessment. "
+                        u"To associate the checkpoint with an assessment, select Edit."
                     )
                 )
             )

--- a/edx_reverification_block/xblock/static/html/studio_preview.html
+++ b/edx_reverification_block/xblock/static/html/studio_preview.html
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-<div class="reverify-preview-msg">{% trans "To preview the checkpoint block, click Preview or View Live in Unit Settings." %}</div>
+<div class="reverify-preview-msg">{% trans "To preview the checkpoint, select View Live Version or Preview." %}</div>

--- a/edx_reverification_block/xblock/static/js/checkpoint_edit.js
+++ b/edx_reverification_block/xblock/static/js/checkpoint_edit.js
@@ -17,10 +17,10 @@ function CheckpointEditBlock(runtime, element) {
     function validate(data) {
         var errors = [];
         if ( !validators.string(data.related_assessment) ) {
-            errors.push(gettext("Related Assessment field cannot be empty."));
+            errors.push(gettext("The Associated Assessment field cannot be empty."));
         }
         if ( !validators.number(data.attempts) ) {
-            errors.push(gettext("Attempts field should be a positive number."));
+            errors.push(gettext("You must select a value other than 0 for the Verification Attempts field."));
         } else {
             data.attempts = Math.floor(Number(data.attempts));
         }
@@ -44,14 +44,14 @@ function CheckpointEditBlock(runtime, element) {
                     runtime.notify('save', {state: 'end'});
                 } else {
                     runtime.notify('error', {
-                        title: gettext('Re-Verification Save Error'),
-                        message: gettext('An unexpected error occurred while saving.')
+                        title: gettext('Reverification Save Error'),
+                        message: gettext('An unexpected error occurred. Select Save to try again.')
                     });
                 }
             });
         } else {
-            var message = gettext("Validation Error[s]:") + "<br>" + validation_errors.join(' <br>');
-            runtime.notify('error', {title: gettext('Re-Verification Save Error'), message: message});
+            var message = '<br>' + validation_errors.join(' <br>');
+            runtime.notify('error', {title: gettext('Reverification Save Error'), message: message});
         }
     });
 

--- a/edx_reverification_block/xblock/tests/test_reverification_block.py
+++ b/edx_reverification_block/xblock/tests/test_reverification_block.py
@@ -44,7 +44,7 @@ class TestStudioPreview(XBlockHandlerTestCaseMixin, TestCase):
         resp = self.request(xblock, 'studio_submit', data, response_format='json')
         self.assertTrue(resp.get('result'))
         xblock_fragment = self.runtime.render(xblock, "student_view")
-        self.assertIn('click Preview or View Live', xblock_fragment.body_html())
+        self.assertIn('select View Live Version or Preview', xblock_fragment.body_html())
 
     @scenario(TESTS_BASE_DIR + '/data/basic_scenario.xml', user_id='bob')
     def test_studio_preview_validation(self, xblock):
@@ -61,7 +61,7 @@ class TestStudioPreview(XBlockHandlerTestCaseMixin, TestCase):
         self.assertEqual(len(validation_messages.to_json().get('messages')), 1)
         self.assertEqual(validation_messages.to_json().get('messages')[0].get('type'), 'warning')
         self.assertIn(
-            "This checkpoint is not associated with an assessment yet. Please select an Assessment.",
+            "To associate the checkpoint with an assessment, select Edit.",
             validation_messages.to_json().get('messages')[0].get('text')
         )
 
@@ -85,9 +85,9 @@ class TestStudioEditing(XBlockHandlerTestCaseMixin, TestCase):
         xblock_fragment = self.runtime.render(xblock, "studio_view")
         editing_html = xblock_fragment.body_html()
 
-        self.assertIn("Related Assessment", editing_html)
+        self.assertIn("Associated Assessment", editing_html)
         self.assertIn(xblock.related_assessment, editing_html)
-        self.assertIn("Attempts", editing_html)
+        self.assertIn("attempts", editing_html)
         self.assertIn(unicode(xblock.attempts), editing_html)
 
     @ddt.data(


### PR DESCRIPTION
ECOM-1992

ICRV xblocks UI texts have been updated in this PR. Following are the updated text changes
<img width="904" alt="screen shot 2015-08-06 at 2 31 58 pm" src="https://cloud.githubusercontent.com/assets/7567613/9108549/6d8d03aa-3c48-11e5-8800-de910a37d6f9.png">
<img width="903" alt="screen shot 2015-08-06 at 2 32 34 pm" src="https://cloud.githubusercontent.com/assets/7567613/9108548/6d8c4e4c-3c48-11e5-8224-6b7e5299dfb8.png">
<img width="515" alt="screen shot 2015-08-06 at 2 32 56 pm" src="https://cloud.githubusercontent.com/assets/7567613/9108550/6d8e59a8-3c48-11e5-84f3-b6c1f3643238.png">


